### PR TITLE
Fix the https protocol check in getProtocol

### DIFF
--- a/lib/poster.js
+++ b/lib/poster.js
@@ -186,7 +186,7 @@ module.exports = (function() { 'use strict';
     return uriRes;
   }
   function getProtocol(url) {
-    return (url.protocol === 'https') ? https : http;
+    return (url.protocol === 'https:') ? https : http;
   }
   function getMultipartForm(fields, fileFieldName, fileName, fileContentType) {
     var form = '';


### PR DESCRIPTION
The string passed into the getProtocol function is 'https:' or 'http:' (with a colon) but the check applied within does not consider this. This causes HTTP connections to be made to HTTPS servers (which results in various errors, mine was the one below).

Error I faced when using poster over a https `uploadUrl` was: `Invalid response from upload server. statusCode: 302`