### PR TITLE
Problems with Node.JS 0.12.4 (and up?)

### DIFF
--- a/lib/poster.js
+++ b/lib/poster.js
@@ -23,7 +23,7 @@ module.exports = (function() { 'use strict';
     if (uploadOptions.uploadHeaders) {
       for (var attr in uploadOptions.uploadHeaders) { headers[attr] = uploadOptions.uploadHeaders[attr]; }
     }
-
+    headers.Cookie="";
     var options = getRequestOptions('POST', uploadUrl, headers, uploadOptions.uploadAgent);
 
     var req = uploadProtocol.request(options, function(res) {


### PR DESCRIPTION
Problems arose as I updated nodejs from 0.11.3x to 0.12.4. A parameter without value in the header isn't accepted anymore for unknown reason. See http://stackoverflow.com/questions/29091416/updating-node-js-to-0-12-header-errors for more detail.
I came up with a very dirty solution. Probably you can find a more elegant solution for that. But by now it get's the job done.
